### PR TITLE
Fix issues with composer parse error and mass assignment exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": ">=7.1",
         "illuminate/database": "^5.6",
-        "illuminate/support": "~5.6",
-        "mockery/mockery": "~1.0",
+        "illuminate/support": "~5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "mockery/mockery": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Traits/HasNestedAttributesTrait.php
+++ b/src/Traits/HasNestedAttributesTrait.php
@@ -8,12 +8,11 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Builder;
 
 trait HasNestedAttributesTrait
 {
     /**
-     * Defined nested attributes 
+     * Defined nested attributes
      *
      * @var array
      */
@@ -53,12 +52,13 @@ trait HasNestedAttributesTrait
             foreach ($this->nested as $attr) {
                 if (isset($attributes[$attr])) {
                     $this->acceptNestedAttributesFor[$attr] = $attributes[$attr];
+                    unset($attributes[$attr]);
                 }
             }
         }
         return parent::fill($attributes);
     }
-    
+
     /**
      * Save the model to the database.
      *
@@ -75,7 +75,7 @@ trait HasNestedAttributesTrait
 
         foreach ($this->getAcceptNestedAttributesFor() as $attribute => $stack) {
             $methodName = lcfirst(join(array_map('ucfirst', explode('_', $attribute))));
-    
+
             if (!method_exists($this, $methodName)) {
                 throw new Exception('The nested atribute relation "' . $methodName . '" does not exists.');
             }
@@ -86,7 +86,7 @@ trait HasNestedAttributesTrait
                 if (!$this->saveNestedAttributes($relation, $stack)) {
                     return false;
                 }
-            } else if ($relation instanceof HasMany || $relation instanceof MorphMany) {
+            } elseif ($relation instanceof HasMany || $relation instanceof MorphMany) {
                 foreach ($stack as $params) {
                     if (!$this->saveManyNestedAttributes($this->$methodName(), $params)) {
                         return false;
@@ -115,7 +115,7 @@ trait HasNestedAttributesTrait
                 return $model->delete();
             }
             return $model->update($stack);
-        } else if ($relation->create($stack)) {
+        } elseif ($relation->create($stack)) {
             return true;
         }
         return false;
@@ -135,9 +135,9 @@ trait HasNestedAttributesTrait
 
             if ($this->allowDestroyNestedAttributes($params)) {
                 return $model->delete();
-            }            
+            }
             return $model->update($params);
-        } else if ($relation->create($params)) {
+        } elseif ($relation->create($params)) {
             return true;
         }
         return false;


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/mits87/eloquent-nested-attributes/issues/4

- Fixes the composer.json parse error (there was a trailing comma)
- Moves the Mockery dependency into dev (it's not used outside testing)
- Adds an `unset($attributes[$attr]` line in the fillable override. Forgetting to clean the attributes array was causing a mass assignment exception to be thrown when passing the `$attributes` array to `parent::fill($attributes)`
- Adds regression test for bug fix

## How to validate

1. Run the tests
2. Try installing locally with composer. I followed this article to set up a local environment: https://johannespichler.com/developing-composer-packages-locally/ Since I use per-project homestead installations in my projects I actually cloned the package into the root of my app (and added it to my root project's gitignore) and used and absolute path for the symlink. You also have to run the `composer require ...` command from inside the container or the symlink will point to your host machine.